### PR TITLE
Add the govuk_envsys module from govuk-puppet

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: docker
+  use_sudo: false
+
+provisioner:
+  name: puppet_apply
+  require_chef_for_busser: false
+  manifests_path: .
+  modules_path: ../
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    provisioner:
+      manifest: site.pp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+language: ruby
+before_install: rm Gemfile.lock || true
+script: bundle exec rake test
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.8.0"
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: ruby
 before_install: rm Gemfile.lock || true
+bundler_args: --without functional_tests
 script: bundle exec rake test
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 5.2.0'
+
+gem 'rake', '~> 12.1.0'
+gem 'puppet-lint', '~> 2.3.3'
+gem 'rspec-puppet', '~> 2.6.9'
+gem 'puppetlabs_spec_helper', '~> 2.3.2'
+gem 'puppet-syntax', '~> 2.4.1'
+

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,9 @@ gem 'rspec-puppet', '~> 2.6.9'
 gem 'puppetlabs_spec_helper', '~> 2.3.2'
 gem 'puppet-syntax', '~> 2.4.1'
 
+group :functional_tests do
+  gem 'test-kitchen'
+  gem 'kitchen-docker'
+  gem 'kitchen-inspec'
+  gem 'kitchen-puppet'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+PuppetLint.configuration.fail_on_warnings = true
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/files/etc/environment
+++ b/files/etc/environment
@@ -1,0 +1,3 @@
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
+LC_ALL=en_GB.UTF-8
+TZ=UTC

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_envsys
+#
+# Manage /etc/environment. In addition to the stock entries like PATH and
+# LC_ALL.
+#
+class govuk_envsys {
+  file { '/etc/environment':
+    ensure  => present,
+    content => file('govuk_envsys/etc/environment'),
+  }
+}

--- a/site.pp
+++ b/site.pp
@@ -1,0 +1,1 @@
+include govuk_envsys

--- a/spec/classes/govuk_envsys_spec.rb
+++ b/spec/classes/govuk_envsys_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../spec_helper'
+
+describe 'govuk_envsys', :type => :class do
+  let(:file_path) { '/etc/environment' }
+  context 'as a file not a template' do
+    let(:facts) {{}}
+
+    # with_content does not currently accept an argument.
+    it { is_expected.to contain_file(file_path).with_content(/LC_ALL=en_GB.UTF-8/) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/test/integration/default/govuk_envsys_spec.rb
+++ b/test/integration/default/govuk_envsys_spec.rb
@@ -1,0 +1,3 @@
+describe file('/etc/environment') do
+  its('content') { should include('LC_ALL=en_GB.UTF-8') }
+end


### PR DESCRIPTION
- This is an extraction of the code from https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_envsys with the addition of tests, updated Ruby versions and Kitchen CI config.